### PR TITLE
Change deploy workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,3 @@ cypress/screenshots
 cypress/videos
 
 .now
-now.json

--- a/README.md
+++ b/README.md
@@ -62,22 +62,24 @@ To deploy this app, you will need a [zeit.co account](https://zeit.co/signup).
 
 Run `npx now login` (in this directory) to login to your account.
 
-To set up your project, you will need to generate a `now.json` by
-running `npm run setup`. Follow the instructions in your terminal to
-set up a new project and it will generate a now.json file for you.
+To deploy your project, run `npx now --prod`. The first time you run this command, you will be prompted with a
+series of questions.
 
-Once you've set up your now.json, run `npx now --prod --confirm`.
+For most of these questions, you can hit enter to use the suggested value.
+**When asked "What's your project's name", enter in a project name in the form _`cs48-githubid-lab00`_,
+replacing _`githubid`_ with your github id**
 
-- The first time you deploy your app, you will be asked a few
-  questions about the app.
-- For most of the questions, you can hit enter to go with the suggested value,
-  though you may want to choose your own app name.
+If the deployment was successful, you should see the line `✅ Production: <production url> [copied to clipboard]`.
+`<production url>` is the link to your running production app. If you are working locally, this value should be
+copied to your clipboard.
 
-If your deployment was successful, the link to the production app
-should be copied to your clipboard.
+If you visit your production app, you may notice that your app is responding with a 500 Internal Server Error. This
+is because the server has not been configured with your Auth0 configuration.
 
-The first time you do this, you will have to make a small modification
-to your Auth0 configuration. Follow the instructions in
+To set this up, run `npm run setup`. You will be prompted to paste the url of your production app, which you should have
+from when you first deployed the app. The setup script will automatically upload your credentials and redeploy your app.
+
+You will also have to make a small modification to your Auth0 configuration. Follow the instructions in
 [docs/auth0-production.md](./docs/auth0-production.md) to configure your
 app for OAuth.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7240,9 +7240,9 @@
       }
     },
     "now": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/now/-/now-17.1.1.tgz",
-      "integrity": "sha512-Hmh8eMSt4FxS1YBwaLrdJuzEVm6ZtS4JCY0AZE+JTnTtDGHVaQMUI85FaPvasSIhKLa+7xf6v7lmTgM39VW/8w==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/now/-/now-18.0.0.tgz",
+      "integrity": "sha512-MVskFV3xH1hMkpTewPCb3p0SQ17hL7EI1Zb+Ij2wYiRV3X0a6G91GdE2vvFlhsK6rhRHKHZnDQkZ0AnkpnfzHA==",
       "dev": true
     },
     "npm-run-all": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dotenv": "^8.2.0",
     "husky": "^4.2.3",
     "inquirer": "^7.1.0",
-    "now": "^17.1.1",
+    "now": "^18.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.2",
     "pretty-quick": "^2.0.1",

--- a/setup_now.js
+++ b/setup_now.js
@@ -37,6 +37,9 @@ inquirer
     addEnvVar("AUTH0_CLIENT_SECRET", process.env.AUTH0_CLIENT_SECRET);
     addEnvVar("REDIRECT_URI", `${url}/api/callback`);
     addEnvVar("POST_LOGOUT_REDIRECT_URI", url);
+    // This generates a random value for SESSION_COOKIE_SECRET
+    // The importance of this is explained here:
+    //   https://martinfowler.com/articles/session-secret.html
     addEnvVar("SESSION_COOKIE_SECRET", crypto.randomBytes(32).toString("hex"));
 
     console.log("Configured all environment variables. Redeploying...");

--- a/setup_now.js
+++ b/setup_now.js
@@ -1,25 +1,16 @@
-// Read secrets from .env file and add them to now app
-// Prepend secrets with a string that disambiguates different
-// applications.
-
 require("dotenv").config();
 const crypto = require("crypto");
 const { execSync } = require("child_process");
-const fs = require("fs");
 const inquirer = require("inquirer");
 
-function getAppName(github, app) {
-  return `cs48-${github}-${app}`.toLowerCase();
-}
-
-function addSecret(appName, key, value) {
+function addEnvVar(key, value) {
   try {
-    execSync(`npx now secrets add "${appName}-${key}" "${value}"`, {
-      stdio: "inherit",
+    execSync(`npx now env add "${key}" production`, {
+      input: value,
     });
   } catch {
     console.error(
-      `Could not add "${appName}-${key}". If it already exists, that's fine.`
+      `Could not add "${key}". If it already exists, that's fine. If you want to update an existing environment variable, run "npx now env rm ${key} production"`
     );
   }
 }
@@ -28,70 +19,29 @@ inquirer
   .prompt([
     {
       type: "input",
-      name: "github",
-      message: "What's your github username?",
+      name: "url",
+      message: "What is your app's production url?",
       validate: (value) => {
-        // from https://github.com/shinnn/github-username-regex
-        const valid = /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i.test(value);
-
-        return valid || "You must enter a valid GitHub username!";
-      },
-    },
-    {
-      type: "input",
-      name: "app",
-      message: "What do you want to name your app?",
-      validate: (value, { github }) => {
-        const appName = getAppName(github, value);
-        const valid =
-          appName.length <= 52 &&
-          !/[^a-z0-9\-]/.test(value) &&
-          !/--/.test(value) &&
-          !/-$/.test(value);
+        const valid = /^https:\/\//.test(value);
 
         return (
           valid ||
-          "Invalid app name. The full app name must be no more than 52 characters and only contain alphanumeric characters and non-consecutive/non-trailing dashes."
+          "Invalid url. This should be the production url copied from running 'npx now'"
         );
       },
     },
   ])
-  .then(({ github, app }) => {
-    const appName = getAppName(github, app);
-    const cookieSecret = crypto.randomBytes(32).toString("hex");
-    // This generates a random value for SESSION_COOKIE_SECRET
-    // The importance of this is explained here:
-    //   https://martinfowler.com/articles/session-secret.html
+  .then(({ url }) => {
+    addEnvVar("AUTH0_DOMAIN", process.env.AUTH0_DOMAIN);
+    addEnvVar("AUTH0_CLIENT_ID", process.env.AUTH0_CLIENT_ID);
+    addEnvVar("AUTH0_CLIENT_SECRET", process.env.AUTH0_CLIENT_SECRET);
+    addEnvVar("REDIRECT_URI", `${url}/api/callback`);
+    addEnvVar("POST_LOGOUT_REDIRECT_URI", url);
+    addEnvVar("SESSION_COOKIE_SECRET", crypto.randomBytes(32).toString("hex"));
 
-    const secrets = [
-      ["AUTH0_DOMAIN", null, process.env.AUTH0_DOMAIN],
-      ["AUTH0_CLIENT_ID", null, process.env.AUTH0_CLIENT_ID],
-      ["AUTH0_CLIENT_SECRET", "client_secret", process.env.AUTH0_CLIENT_SECRET],
-      ["REDIRECT_URI", null, `https://${appName}.now.sh/api/callback`],
-      ["POST_LOGOUT_REDIRECT_URI", null, `https://${appName}.now.sh/`],
-      ["SESSION_COOKIE_SECRET", "cookie_secret", cookieSecret],
-    ];
+    console.log("Configured all environment variables. Redeploying...");
 
-    const json = {
-      name: appName,
-      build: {
-        env: {},
-      },
-    };
-
-    for (const [jsonKey, secretKeyName, value] of secrets) {
-      if (secretKeyName) {
-        json.build.env[jsonKey] = `@${appName}-${secretKeyName}`;
-        addSecret(appName, secretKeyName, value);
-      } else {
-        json.build.env[jsonKey] = value;
-      }
-    }
-
-    fs.writeFileSync("now.json", JSON.stringify(json, null, "\t"));
-
-    console.log(
-      "Created a now.json file, you're now ready to deploy by running:"
-    );
-    console.log("        npx now --prod --confirm");
+    execSync("npx now --prod", {
+      stdio: "inherit",
+    });
   });

--- a/utils/auth0.js
+++ b/utils/auth0.js
@@ -1,15 +1,17 @@
 import { initAuth0 } from "@auth0/nextjs-auth0";
 import config from "./config";
 
-export default initAuth0({
-  clientId: config.AUTH0_CLIENT_ID,
-  clientSecret: config.AUTH0_CLIENT_SECRET,
-  scope: config.AUTH0_SCOPE,
-  domain: config.AUTH0_DOMAIN,
-  redirectUri: config.REDIRECT_URI,
-  postLogoutRedirectUri: config.POST_LOGOUT_REDIRECT_URI,
-  session: {
-    cookieSecret: config.SESSION_COOKIE_SECRET,
-    cookieLifetime: config.SESSION_COOKIE_LIFETIME,
-  },
-});
+export default config.MOCK_AUTH0
+  ? {}
+  : initAuth0({
+      clientId: config.AUTH0_CLIENT_ID,
+      clientSecret: config.AUTH0_CLIENT_SECRET,
+      scope: config.AUTH0_SCOPE,
+      domain: config.AUTH0_DOMAIN,
+      redirectUri: config.REDIRECT_URI,
+      postLogoutRedirectUri: config.POST_LOGOUT_REDIRECT_URI,
+      session: {
+        cookieSecret: config.SESSION_COOKIE_SECRET,
+        cookieLifetime: config.SESSION_COOKIE_LIFETIME,
+      },
+    });

--- a/utils/config.js
+++ b/utils/config.js
@@ -3,6 +3,9 @@ if (typeof window === "undefined") {
    * Settings exposed to the server.
    */
   module.exports = {
+    // For the initial deployment, Auth0 configuration will not be initialized.
+    // MOCK_AUTH0 is true when Auth0 isn't configured so that the initial build will succeed.
+    MOCK_AUTH0: !process.env.AUTH0_DOMAIN,
     AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
     AUTH0_CLIENT_SECRET: process.env.AUTH0_CLIENT_SECRET,
     AUTH0_SCOPE: process.env.AUTH0_SCOPE,


### PR DESCRIPTION
This PR updates the deployment workflow to use Zeit Now's new project-local environment variables.

The workflow is now as follows:
1. Run `npx now` to create an initial (broken) deployment
2. Run `npm run setup` to upload the environment variables, fixing the deployment