### PR TITLE
Fix setup script

### DIFF
--- a/setup_now.js
+++ b/setup_now.js
@@ -6,9 +6,7 @@ const inquirer = require("inquirer");
 
 function addEnvVar(key, value) {
   try {
-    execSync(`npx now env add "${key}" production`, {
-      input: value,
-    });
+    execSync(`echo "${value}" | npx now env add "${key}" production`);
   } catch {
     console.error(
       `Could not add "${key}". If it already exists, that's fine. If you want to update an existing environment variable, run "npx now env rm ${key} production"`

--- a/setup_now.js
+++ b/setup_now.js
@@ -1,6 +1,7 @@
 require("dotenv").config();
 const crypto = require("crypto");
 const { execSync } = require("child_process");
+const url = require("url");
 const inquirer = require("inquirer");
 
 function addEnvVar(key, value) {
@@ -19,7 +20,7 @@ inquirer
   .prompt([
     {
       type: "input",
-      name: "url",
+      name: "prodUrl",
       message: "What is your app's production url?",
       validate: (value) => {
         const valid = /^https:\/\//.test(value);
@@ -31,12 +32,12 @@ inquirer
       },
     },
   ])
-  .then(({ url }) => {
+  .then(({ prodUrl }) => {
     addEnvVar("AUTH0_DOMAIN", process.env.AUTH0_DOMAIN);
     addEnvVar("AUTH0_CLIENT_ID", process.env.AUTH0_CLIENT_ID);
     addEnvVar("AUTH0_CLIENT_SECRET", process.env.AUTH0_CLIENT_SECRET);
-    addEnvVar("REDIRECT_URI", `${url}/api/callback`);
-    addEnvVar("POST_LOGOUT_REDIRECT_URI", url);
+    addEnvVar("REDIRECT_URI", url.resolve(prodUrl, "/api/callback"));
+    addEnvVar("POST_LOGOUT_REDIRECT_URI", prodUrl);
     // This generates a random value for SESSION_COOKIE_SECRET
     // The importance of this is explained here:
     //   https://martinfowler.com/articles/session-secret.html

--- a/setup_now.js
+++ b/setup_now.js
@@ -6,7 +6,7 @@ const inquirer = require("inquirer");
 
 function addEnvVar(key, value) {
   try {
-    execSync(`echo "${value}" | npx now env add "${key}" production`);
+    execSync(`printf "${value}" | npx now env add "${key}" production`);
   } catch {
     console.error(
       `Could not add "${key}". If it already exists, that's fine. If you want to update an existing environment variable, run "npx now env rm ${key} production"`

--- a/setup_now.js
+++ b/setup_now.js
@@ -31,6 +31,8 @@ inquirer
     },
   ])
   .then(({ prodUrl }) => {
+    prodUrl = prodUrl.trim();
+
     addEnvVar("AUTH0_DOMAIN", process.env.AUTH0_DOMAIN);
     addEnvVar("AUTH0_CLIENT_ID", process.env.AUTH0_CLIENT_ID);
     addEnvVar("AUTH0_CLIENT_SECRET", process.env.AUTH0_CLIENT_SECRET);


### PR DESCRIPTION
This PR makes a couple of changes to the setup script that fix some of the errors that students have been getting:

1. The `execSync` function now uses printf and pipe instead of the built-in input parameter, which should fix some windows-specific bugs (thanks @andrewhlu!)

2. The redirect URL is now properly derived via `url.resolve` instead of naive string concatenation. This resolves an issue students were having where they copied the production URL from the browser instead of the one from the terminal.